### PR TITLE
update DESCRIPTION and install instrucitons for R 4.3.x

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: FastReseg
 Title: Detection and Correction of Cell Segmentation Error Based on Spatial Profile of Transcripts
-Version: 1.0.0
+Version: 1.0.1
 Authors@R: c(
   person(given = "Patrick", family = "Danaher", email = "pdanaher@nanostring.com", role = c("aut"), comment = c(ORCID = "0000-0002-2844-5883")),
   person(given = "Lidan", family = "Wu", email = "lwu@nanostring.com", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-3150-6170"))
@@ -14,15 +14,12 @@ Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1
-Additional_repositories:
-    https://github.com/drieslab/GiottoClass, 
-    https://github.com/drieslab/Giotto
 Depends:
     R (>= 3.5.0)
 Imports:
     lmtest,
     MASS,
-    Matrix,
+    Matrix(>= 1.6.2),
     stats,
     methods, 
     utils, 
@@ -37,16 +34,19 @@ Imports:
     ggplot2,
     fs,
     stringr, 
+    GiottoUtils(>= 0.1.6),
     GiottoClass(>= 0.2.3),
     geometry(>= 0.4.6.1),
     parallel
+Remotes: 
+  github::drieslab/GiottoUtils, 
+  github::drieslab/GiottoClass
 Suggests: 
     testthat (>= 3.0.0),
     kableExtra,
     knitr,
     rmarkdown,
     RTriangle (>= 1.6-0.10),
-    deldir (>= 1.0.6),
-    Giotto
+    deldir (>= 1.0.6)
 Config/testthat/edition: 3
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # FastReseg
 
+# FastReseg 1.0.1
+
+* Update DESCRIPTION with github remotes and include installation instructions for R 4.3.x
+
 # FastReseg 1.0.0
 
 * Addresses compatibility with new latest.fovs that has additional column for acquisition order

--- a/README.md
+++ b/README.md
@@ -47,10 +47,17 @@ See the "vignettes" folder.
 ### Installation
 #### Install the development version from GitHub
 ```
+# to use with R 4.3.x
+if(!requireNamespace("GiottoUtils", quietly=TRUE))
+  remotes::install_github("drieslab/GiottoClass", upgrade="never", 
+  ref = "bec3c79398a9aff299a01cc152ff6f2245a8f965")
+  
 if(!requireNamespace("GiottoClass", quietly=TRUE))
   remotes::install_github("drieslab/GiottoClass", upgrade="never", 
   ref = "6d9d385beebcc57b78d34ffbe30be1ef0a184681")
-  
+```
+```
+# install FastReseg from github
 devtools::install_github("Nanostring-Biostats/FastReseg", 
                          build_vignettes = TRUE, ref = "main")
 ```


### PR DESCRIPTION
This PR 

- bump version to 1.0.1
- update DESCRIPTION with `remotes` and remove `Giotto` from `suggests` 
- add package version information for installation with R 4.3.x in readme

`R CMD build` passed. without issue 
![image](https://github.com/user-attachments/assets/26cb9855-9215-4215-9262-8e88abb95b89)

`R CMD check` gave no error.
![image](https://github.com/user-attachments/assets/d61a8606-dc24-4bfa-abcc-60e74a936207)
![image](https://github.com/user-attachments/assets/70653019-75e2-49b2-905c-b1fb63480afd)
![image](https://github.com/user-attachments/assets/5c7d63df-a290-496f-9929-0c90c3e52c85)

